### PR TITLE
Update package to use iframe embed API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,20 +1,112 @@
 import "react-app-polyfill/ie11";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
-import { HTMLStreamElement, Stream } from "../.";
+import { Stream, StreamPlayerApi } from "../.";
+import { useState } from "react";
+
+function useLocalStorageState<T>(key: string, defaultValue: T) {
+  const valueFromLocalStorage = localStorage.getItem(key);
+
+  const [value, setValue] = useState<T>(
+    valueFromLocalStorage === null
+      ? defaultValue
+      : JSON.parse(valueFromLocalStorage)
+  );
+
+  return [
+    value,
+    (update: T) => {
+      if (typeof update === "function") {
+        setValue((prev: T) => {
+          const newValue = update(prev);
+          localStorage.setItem(key, JSON.stringify(newValue));
+          return newValue;
+        });
+      } else {
+        localStorage.setItem(key, JSON.stringify(update));
+        setValue(update);
+      }
+    },
+  ] as const;
+}
+
+type Primitive = string | number | boolean;
+
+function useInput<T extends Primitive>(
+  name: string,
+  defaultValue: T,
+  props: Omit<JSX.IntrinsicElements["input"], "value" | "checked" | "onChange">
+) {
+  const [value, setValue] = useLocalStorageState(name, defaultValue);
+  return {
+    value,
+    input: (
+      <label
+        style={{
+          display: "inline-block",
+          border: "1px solid",
+          padding: "4px 8px",
+        }}
+      >
+        {name}{" "}
+        <input
+          {...props}
+          checked={typeof value === "boolean" ? value : undefined}
+          value={
+            typeof value === "string" || typeof value === "number"
+              ? value
+              : undefined
+          }
+          onChange={(e) =>
+            setValue(
+              defaultValue.constructor(
+                typeof defaultValue === "boolean"
+                  ? e.target.checked
+                  : e.target.value
+              )
+            )
+          }
+        />
+      </label>
+    ),
+  };
+}
 
 const App = () => {
-  const ref = React.useRef<HTMLStreamElement>(null);
+  const ref = React.useRef<StreamPlayerApi>(null);
+
+  const autoplay = useInput("autoplay", true, { type: "checkbox" });
+  const muted = useInput("muted", true, { type: "checkbox" });
+  const loop = useInput("loop", true, { type: "checkbox" });
+  const controls = useInput("controls", true, { type: "checkbox" });
+  const responsive = useInput("responsive", true, { type: "checkbox" });
+  const volume = useInput("volume", 1, {
+    type: "range",
+    min: 0,
+    max: 1,
+    step: 0.01,
+  });
 
   return (
     <div>
       <Stream
         streamRef={ref}
         src="4bcf13d23290043d9efb344b56200ebd"
-        muted
-        autoplay
-        controls
+        muted={muted.value}
+        loop={loop.value}
+        controls={controls.value}
+        responsive={responsive.value}
+        autoplay={autoplay.value}
+        volume={volume.value}
       />
+      <div>
+        {volume.input}
+        {muted.input}
+        {autoplay.input}
+        {loop.input}
+        {controls.input}
+        {responsive.input}
+      </div>
       <button
         onClick={() => {
           if (ref.current) {
@@ -23,6 +115,15 @@ const App = () => {
         }}
       >
         seek to 30s
+      </button>
+      <button
+        onClick={() => {
+          if (ref.current) {
+            ref.current.play();
+          }
+        }}
+      >
+        play
       </button>
     </div>
   );

--- a/src/Stream.tsx
+++ b/src/Stream.tsx
@@ -2,104 +2,18 @@ import React, {
   useRef,
   useEffect,
   RefObject,
-  MutableRefObject,
   FC,
+  useState,
+  CSSProperties,
+  useMemo,
+  MutableRefObject,
 } from "react";
-
-const scriptLocation =
-  "https://embed.videodelivery.net/embed/r4xu.fla9.latest.js";
-
-function useStreamElement(
-  containerRef: RefObject<HTMLDivElement>,
-  streamRef: MutableRefObject<HTMLStreamElement | null>
-) {
-  // Need to create stream element with document.createElement
-  // because React will log console warnings if we render
-  // invalid HTML elements in JSX
-  useEffect(() => {
-    if (!containerRef.current) return;
-    // grab current container from ref so we can use it in the
-    // callback we return for cleanup.
-    const container = containerRef.current;
-    const stream = document.createElement("stream") as HTMLStreamElement;
-
-    // store stream element on ref
-    streamRef.current = stream;
-
-    // insert stream element into dom
-    container.appendChild(stream);
-    return () => {
-      // clean up before unmounting or re-running the effect
-      container.removeChild(stream);
-    };
-  }, [streamRef, containerRef]);
-}
-
-declare global {
-  interface Window {
-    __stream?: {
-      init: () => void;
-      initElement: (streamElement: HTMLStreamElement) => void;
-    };
-  }
-}
+import { StreamPlayerApi, StreamProps, VideoDimensions } from "types";
+import { useStreamSDK } from "./useStreamSDK";
+import { useIframeSrc } from "./useIframeSrc";
 
 /**
- * Script to load the player. This initializes the player on the stream element
- */
-function useStreamScript(ref: RefObject<HTMLStreamElement>) {
-  useEffect(() => {
-    const existingScript = document.querySelector<HTMLScriptElement>(
-      `script[src="${scriptLocation}"]`
-    );
-    if (existingScript === null) {
-      const streamScript = document.createElement("script");
-      streamScript.setAttribute("data-cfasync", "false");
-      streamScript.setAttribute("defer", "true");
-      streamScript.setAttribute("type", "text/javascript");
-      streamScript.setAttribute("src", scriptLocation);
-      document.head.appendChild(streamScript);
-      return;
-    }
-
-    const streamElement = ref.current;
-    if (window.__stream && streamElement) {
-      window.__stream.initElement(streamElement);
-    }
-
-    // no dependencies in the dependency array means this only fires on mount
-    // and the cleanup only fires on unmount.
-  }, []);
-}
-
-// Creating a type alias for this so we can modify properties on it later
-export type HTMLStreamElement = HTMLVideoElement;
-
-type Primitive = string | number | boolean;
-
-/**
- * Hook for syncing attributes to an element when they change
- */
-function useAttribute(
-  attributeName: string,
-  ref: RefObject<HTMLStreamElement>,
-  value?: Primitive
-) {
-  useEffect(() => {
-    if (!ref.current) return;
-    const el = ref.current;
-    // explicitly checking for false or undefined to remove attribbutes
-    //  so that other falsy values such as 0 or "" may be set
-    if (value === false || value === undefined) {
-      el.removeAttribute(attributeName);
-    } else {
-      el.setAttribute(attributeName, value.toString());
-    }
-  }, [attributeName, value, ref]);
-}
-
-/**
- * Hook for syncing properties to an element when they change
+ * Hook for syncing properties to the SDK api when they change
  */
 function useProperty<T, Key extends keyof T>(
   name: Key,
@@ -118,8 +32,8 @@ function useProperty<T, Key extends keyof T>(
  */
 function useEvent(
   event: string,
-  ref: RefObject<HTMLStreamElement>,
-  callback: EventListener = noop
+  ref: MutableRefObject<StreamPlayerApi | undefined>,
+  callback: () => void = noop
 ) {
   useEffect(() => {
     if (!ref.current) return;
@@ -135,193 +49,61 @@ function useEvent(
 // when no callback is provided
 const noop = () => {};
 
-type AttributeProps = {
-  /**
-   * Either the video id or the signed url for the video you’ve uploaded to Cloudflare Stream should be included here.
-   */
-  src: string;
-  adUrl?: string;
-  /**
-   * The height of the video’s display area, in CSS pixels.
-   */
-  height?: string;
-  /**
-   * The width of the video’s display area, in CSS pixels.
-   */
-  width?: string;
-  /**
-   * A URL for an image to be shown before the video is started or while the video is downloading. If this attribute isn’t specified, a thumbnail image of the video is shown.
-   */
-  poster?: string;
+export const Stream: FC<StreamProps> = (props) => {
+  const streamSdk = useStreamSDK();
+  return streamSdk ? <StreamEmbed {...props} /> : null;
 };
 
-type PropertyProps = {
-  /**
-   * Tells the browser to immediately start downloading the video and play it as soon as it can. Note that mobile browsers generally do not support this attribute, the user must tap the screen to begin video playback. Please consider mobile users or users with Internet usage limits as some users don’t have unlimited Internet access before using this attribute.
-   *
-   * To disable video autoplay, the autoplay attribute needs to be removed altogether as this attribute. Setting autoplay="false" will not work; the video will autoplay if the attribute is there in the <stream> tag.
-   *
-   * In addition, some browsers now prevent videos with audio from playing automatically. You may add the mute attribute to allow your videos to autoplay. For more information, [go here](https://webkit.org/blog/6784/new-video-policies-for-ios/).
-   */
-  autoplay?: boolean;
-  /**
-   * Shows the default video controls such as buttons for play/pause, volume controls. You may choose to build buttons and controls that work with the player.
-   */
-  controls?: boolean;
-  /**
-   * Returns the current playback time in seconds. Setting this value seeks the video to a new time.
-   */
-  currentTime?: number;
-  /**
-   * A Boolean attribute which indicates the default setting of the audio contained in the video. If set, the audio will be initially silenced.
-   */
-  muted?: boolean;
-  /**
-   * A Boolean attribute; if included the player will automatically seek back to the start upon reaching the end of the video.
-   */
-  loop?: boolean;
-  /**
-   * This enumerated attribute is intended to provide a hint to the browser about what the author thinks will lead to the best user experience. You may choose to include this attribute as a boolean attribute without a value, or you may specify the value preload="auto" to preload the beginning of the video. Not including the attribute or using preload="metadata" will just load the metadata needed to start video playback when requested.
-   *
-   * The <video> element does not force the browser to follow the value of this attribute; it is a mere hint. Even though the preload="none" option is a valid HTML5 attribute, Stream player will always load some metadata to initialize the player. The amount of data loaded in this case is negligable.
-   */
-  preload?: "auto" | "metadata" | "none" | boolean;
-  /**
-   * Sets volume from 0.0 (silent) to 1.0 (maximum value)
-   */
-  volume?: number;
+const responsiveIframeStyles: CSSProperties = {
+  position: "absolute",
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  height: "100%",
+  width: "100%",
 };
 
-export type Events = {
-  /**
-   * Sent when playback is aborted; for example, if the media is playing and is restarted from the beginning, this event is sent.
-   */
-  onAbort?: EventListener;
-  /**
-   * Sent when enough data is available that the media can be played, at least for a couple of frames.
-   */
-  onCanPlay?: EventListener;
-  /**
-   * Sent when the entire media can be played without interruption, assuming the download rate remains at least at the current level. It will also be fired when playback is toggled between paused and playing. Note: Manually setting the currentTime will eventually fire a canplaythrough event in firefox. Other browsers might not fire this event.
-   */
-  onCanPlayThrough?: EventListener;
-  /**
-   * The metadata has loaded or changed, indicating a change in duration of the media. This is sent, for example, when the media has loaded enough that the duration is known.
-   */
-  onDurationChange?: EventListener;
-  /**
-   * Sent when playback completes.
-   */
-  onEnded?: EventListener;
-  /**
-   * Sent when an error occurs. (e.g. the video has not finished encoding yet, or the video fails to load due to an incorrect signed URL)
-   */
-  onError?: EventListener;
-  /**
-   * The first frame of the media has finished loading.
-   */
-  onLoadedData?: EventListener;
-  /**
-   * The media’s metadata has finished loading; all attributes now contain as much useful information as they’re going to.
-   */
-  onLoadedMetaData?: EventListener;
-  /**
-   * Sent when loading of the media begins.
-   */
-  onLoadStart?: EventListener;
-  /**
-   * Sent when the playback state is changed to paused (paused property is true).
-   */
-  onPause?: EventListener;
-  /**
-   * Sent when the playback state is no longer paused, as a result of the play method, or the autoplay attribute.
-   */
-  onPlay?: EventListener;
-  /**
-   * Sent when the media has enough data to start playing, after the play event, but also when recovering from being stalled, when looping media restarts, and after seeked, if it was playing before seeking.
-   */
-  onPlaying?: EventListener;
-  /**
-   * Sent periodically to inform interested parties of progress downloading the media. Information about the current amount of the media that has been downloaded is available in the media element’s buffered attribute.
-   */
-  onProgress?: EventListener;
-  /**
-   * Sent when the playback speed changes.
-   */
-  onRateChange?: EventListener;
-  /**
-   * Sent when a seek operation completes.
-   */
-  onSeeked?: EventListener;
-  /**
-   * Sent when a seek operation begins.
-   */
-  onSeeking?: EventListener;
-  /**
-   * Sent when the user agent is trying to fetch media data, but data is unexpectedly not forthcoming.
-   */
-  onStalled?: EventListener;
-  /**
-   * Sent when loading of the media is suspended; this may happen either because the download has completed or because it has been paused for any other reason.
-   */
-  onSuspend?: EventListener;
-  /**
-   * The time indicated by the element’s currentTime attribute has changed.
-   */
-  onTimeUpdate?: EventListener;
-  /**
-   * Sent when the audio volume changes (both when the volume is set and when the muted attribute is changed).
-   */
-  onVolumeChange?: EventListener;
-  /**
-   * Sent when the requested operation (such as playback) is delayed pending the completion of another operation (such as a seek).
-   */
-  onWaiting?: EventListener;
-  /**
-   * Fires when ad-url attribute is present and the ad begins playback
-   */
-  onStreamAdStart?: EventListener;
-  /**
-   * Fires when ad-url attribute is present and the ad finishes playback
-   */
-  onStreamAdEnd?: EventListener;
-  /**
-   * Fires when ad-url attribute is present and the ad took too long to load.
-   */
-  onStreamAdTimeout?: EventListener;
+const Container: FC<{
+  responsive: boolean;
+  videoDimensions: VideoDimensions;
+  className?: string;
+}> = ({ children, responsive, className, videoDimensions }) => {
+  const { videoHeight, videoWidth } = videoDimensions;
+  const responsiveStyles: CSSProperties = useMemo<CSSProperties>(
+    () => ({
+      position: "relative",
+      paddingTop:
+        videoWidth > 0 ? `${(videoHeight / videoWidth) * 100}%` : undefined,
+    }),
+    [videoWidth, videoHeight]
+  );
+  return (
+    <div
+      className={className}
+      style={responsive ? responsiveStyles : undefined}
+    >
+      {children}
+    </div>
+  );
 };
 
-/**
- * Type helper that forces type checker to evaluate a type.
- */
-type Compute<T> = T extends Function ? T : {} & { [Key in keyof T]: T[Key] };
-
-export type StreamProps = Compute<
-  {
-    /**
-     * Ref for accessing the underlying stream element. Useful for providing imperative access to the player API:
-     * https://developers.cloudflare.com/stream/viewing-videos/using-the-player-api
-     */
-    streamRef?: MutableRefObject<HTMLStreamElement | null>;
-  } & AttributeProps &
-    PropertyProps &
-    Events
->;
-
-export const Stream: FC<StreamProps> = ({
+export const StreamEmbed: FC<StreamProps> = ({
   src,
   adUrl,
-  controls,
-  muted,
-  autoplay,
-  loop,
-  preload,
+  controls = false,
+  muted = false,
+  autoplay = false,
+  loop = false,
+  preload = "metadata",
   height,
   width,
   poster,
-  currentTime,
-  volume,
+  currentTime = 0,
+  volume = 1,
   streamRef,
+  responsive = true,
+  className,
   onAbort,
   onCanPlay,
   onCanPlayThrough,
@@ -336,6 +118,7 @@ export const Stream: FC<StreamProps> = ({
   onPlaying,
   onProgress,
   onRateChange,
+  onResize,
   onSeeked,
   onSeeking,
   onStalled,
@@ -347,51 +130,46 @@ export const Stream: FC<StreamProps> = ({
   onStreamAdEnd,
   onStreamAdTimeout,
 }) => {
-  // initialize with no argument to get a mutable ref back instead
-  // of readonly RefObject which cannot be mutated directly
-  const internalStreamRef = useRef<HTMLStreamElement>(null);
-  // Because useRef needs to be called the same number of times
-  // across renders, we create an internal ref that we only use
-  // when playerRef is not provided
-  const ref = streamRef ?? internalStreamRef;
-  // initialize with null to get readonly RefObject back since we
-  // don't need to mutate this ref
-  const containerRef = useRef<HTMLDivElement>(null);
+  const internalRef = useRef<StreamPlayerApi>();
+  const ref = streamRef ?? internalRef;
 
-  useStreamElement(containerRef, ref);
+  const [videoDimensions, setVideoDimensions] = useState({
+    videoHeight: 0,
+    videoWidth: 0,
+  });
 
-  // set attributes
-  useAttribute("ad-url", ref, adUrl);
-  useAttribute("src", ref, src);
-  useAttribute("autoplay", ref, autoplay);
-  useAttribute("controls", ref, controls);
-  useAttribute("loop", ref, loop);
-  useAttribute("preload", ref, preload);
-  useAttribute("height", ref, height);
-  useAttribute("width", ref, width);
-  useAttribute("poster", ref, poster);
-  useAttribute("muted", ref, muted);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
 
-  // These props need to be set directly on the stream element as properties
-  // in order for the player to respond to them when they change
-  useProperty("autoplay", ref, autoplay ?? false);
-  useProperty("controls", ref, controls ?? false);
-  useProperty("currentTime", ref, currentTime ?? 0);
-  useProperty("muted", ref, muted ?? false);
-  useProperty("loop", ref, loop ?? false);
-  useProperty("volume", ref, volume ?? 1);
-  useProperty(
-    "preload",
-    ref,
-    typeof preload === "string"
-      ? // if it's a string pass as is
-        preload
-      : // else if it's true, map to auto
-      preload === true
-      ? "auto"
-      : // otherwise (undefined | false) maps to none
-        "none"
-  );
+  const iframeSrc = useIframeSrc(src, {
+    muted,
+    preload,
+    loop,
+    autoplay,
+    controls,
+    poster,
+    adUrl,
+  });
+
+  useProperty("muted", ref, muted);
+  useProperty("controls", ref, controls);
+  useProperty("src", ref, src);
+  useProperty("autoplay", ref, autoplay);
+  useProperty("currentTime", ref, currentTime);
+  useProperty("loop", ref, loop);
+  useProperty("preload", ref, preload);
+  useProperty("volume", ref, volume);
+
+  // instantiate API after properties are bound because we want undefined
+  // values to be set before defining the properties
+  useEffect(() => {
+    if (iframeRef.current && window.Stream) {
+      const api = window.Stream(iframeRef.current);
+      ref.current = api;
+      const { videoHeight, videoWidth } = api;
+      if (videoHeight && videoWidth)
+        setVideoDimensions({ videoHeight, videoWidth });
+    }
+  }, []);
 
   // bind events
   useEvent("abort", ref, onAbort);
@@ -418,9 +196,30 @@ export const Stream: FC<StreamProps> = ({
   useEvent("stream-adstart", ref, onStreamAdStart);
   useEvent("stream-adend", ref, onStreamAdEnd);
   useEvent("stream-adtimeout", ref, onStreamAdTimeout);
+  useEvent("resize", ref, () => {
+    if (ref.current) {
+      const { videoHeight, videoWidth } = ref.current;
+      setVideoDimensions({ videoHeight, videoWidth });
+      onResize && onResize();
+    }
+  });
 
-  // stream element is set up from effects, load script
-  useStreamScript(ref);
-
-  return <div style={{ height, width }} ref={containerRef} />;
+  return (
+    <Container
+      className={className}
+      responsive={responsive}
+      videoDimensions={videoDimensions}
+    >
+      <iframe
+        ref={iframeRef}
+        src={iframeSrc}
+        style={responsive ? responsiveIframeStyles : undefined}
+        frameBorder={0}
+        height={height}
+        width={width}
+        allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;"
+        allowFullScreen
+      />
+    </Container>
+  );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,1 +1,3 @@
-export { Stream, StreamProps, HTMLStreamElement } from "./Stream";
+export { Stream } from "./Stream";
+export { useStreamSDK } from "./useStreamSDK";
+export { StreamPlayerApi, StreamProps } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,11 +73,13 @@ export interface StreamPlayerApi {
    */
   src: string;
   /**
-   * Number representing the intrinsic height of the video in pixels.
+   * Number representing the intrinsic height of the video in pixels. Note that this is specific to the resolution of the actual video depending on the quality being played. For example, a 16:9 video playing at 1080p will have an intrinsic height of 1080.
+   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/videoHeight
    */
   videoHeight: number;
   /**
-   * Number representing the intrinsic width of the video in pixels.
+   * Number representing the intrinsic width of the video in pixels. Note that this is specific to the resolution of the actual video depending on the quality being played. For example, a 16:9 video playing at 1080p will have an intrinsic width of 1920.
+   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/videoWidth
    */
   videoWidth: number;
   /**
@@ -86,7 +88,7 @@ export interface StreamPlayerApi {
   volume: number;
 }
 
-export type StreamProps = {
+export interface StreamProps {
   /**
    * VAST tag for displaying ads
    */
@@ -255,4 +257,4 @@ export type StreamProps = {
    * Fires when ad-url attribute is present and the ad took too long to load.
    */
   onStreamAdTimeout?: () => void;
-};
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,258 @@
+import { MutableRefObject, CSSProperties } from "react";
+
+declare global {
+  interface Window {
+    Stream?: (iframe: HTMLIFrameElement) => StreamPlayerApi;
+  }
+}
+
+export type Preload = "auto" | "metadata" | "none" | boolean;
+
+export interface VideoDimensions {
+  videoHeight: number;
+  videoWidth: number;
+}
+
+export interface StreamPlayerApi {
+  /**
+   * Subscribe to events
+   */
+  addEventListener: (event: string, handler: () => void) => void;
+  /**
+   * VAST tag for displaying ads
+   */
+  adUrl?: string;
+  /**
+   * Tells the browser to immediately start downloading the video and play it as soon as it can. Note that mobile browsers generally do not support this attribute, the user must tap the screen to begin video playback. Please consider mobile users or users with Internet usage limits as some users don’t have unlimited Internet access before using this attribute.
+   *
+   * To disable video autoplay, the autoplay attribute needs to be removed altogether as this attribute. Setting autoplay="false" will not work; the video will autoplay if the attribute is there in the <stream> tag.
+   *
+   * In addition, some browsers now prevent videos with audio from playing automatically. You may add the mute attribute to allow your videos to autoplay. For more information, [go here](https://webkit.org/blog/6784/new-video-policies-for-ios/).
+   */
+  autoplay: boolean;
+  /**
+   * Shows the default video controls such as buttons for play/pause, volume controls. You may choose to build buttons and controls that work with the player.
+   */
+  controls: boolean;
+  /**
+   * Returns the current playback time in seconds. Setting this value seeks the video to a new time.
+   */
+  currentTime: number;
+  /**
+   * A Boolean attribute; if included the player will automatically seek back to the start upon reaching the end of the video.
+   */
+  loop: boolean;
+  /**
+   * A Boolean attribute which indicates the default setting of the audio contained in the video. If set, the audio will be initially silenced.
+   */
+  muted: boolean;
+  /**
+   * Pause the video
+   */
+  pause: () => void;
+  /**
+   * Attempts to play the video. Returns a promise that will resolve if playback begins successfully, and rejects if it fails. The most common reason for this to fail is browser policies which prevent unmuted playback that is not initiated by the user.
+   */
+  play: () => Promise<void>;
+  /**
+   * A URL for an image to be shown before the video is started or while the video is downloading. If this attribute isn’t specified, a thumbnail image of the video is shown.
+   */
+  poster?: string;
+  /**
+   * This enumerated attribute is intended to provide a hint to the browser about what the author thinks will lead to the best user experience. You may choose to include this attribute as a boolean attribute without a value, or you may specify the value preload="auto" to preload the beginning of the video. Not including the attribute or using preload="metadata" will just load the metadata needed to start video playback when requested.
+   *
+   * The <video> element does not force the browser to follow the value of this attribute; it is a mere hint. Even though the preload="none" option is a valid HTML5 attribute, Stream player will always load some metadata to initialize the player. The amount of data loaded in this case is negligable.
+   */
+  preload: Preload;
+  /**
+   * Unsubscribe from events
+   */
+  removeEventListener: (event: string, handler: () => void) => void;
+  /**
+   * Either the video id or the signed url for the video you’ve uploaded to Cloudflare Stream should be included here.
+   */
+  src: string;
+  /**
+   * Number representing the intrinsic height of the video in pixels.
+   */
+  videoHeight: number;
+  /**
+   * Number representing the intrinsic width of the video in pixels.
+   */
+  videoWidth: number;
+  /**
+   * Sets volume from 0.0 (silent) to 1.0 (maximum value)
+   */
+  volume: number;
+}
+
+export type StreamProps = {
+  /**
+   * VAST tag for displaying ads
+   */
+  adUrl?: string;
+  /**
+   * Tells the browser to immediately start downloading the video and play it as soon as it can. Note that mobile browsers generally do not support this attribute, the user must tap the screen to begin video playback. Please consider mobile users or users with Internet usage limits as some users don’t have unlimited Internet access before using this attribute.
+   *
+   * To disable video autoplay, the autoplay attribute needs to be removed altogether as this attribute. Setting autoplay="false" will not work; the video will autoplay if the attribute is there in the <stream> tag.
+   *
+   * In addition, some browsers now prevent videos with audio from playing automatically. You may add the mute attribute to allow your videos to autoplay. For more information, [go here](https://webkit.org/blog/6784/new-video-policies-for-ios/).
+   */
+  autoplay?: boolean;
+  /**
+   * CSS class applied to the containing div
+   */
+  className?: string;
+  /**
+   * Shows the default video controls such as buttons for play/pause, volume controls. You may choose to build buttons and controls that work with the player.
+   */
+  controls?: boolean;
+  /**
+   * Returns the current playback time in seconds. Setting this value seeks the video to a new time.
+   */
+  currentTime?: number;
+  /**
+   * The height of the video’s display area, in CSS pixels.
+   */
+  height?: string;
+  /**
+   * A Boolean attribute; if included the player will automatically seek back to the start upon reaching the end of the video.
+   */
+  loop?: boolean;
+  /**
+   * A Boolean attribute which indicates the default setting of the audio contained in the video. If set, the audio will be initially silenced.
+   */
+  muted?: boolean;
+  /**
+   * A URL for an image to be shown before the video is started or while the video is downloading. If this attribute isn’t specified, a thumbnail image of the video is shown.
+   */
+  poster?: string;
+  /**
+   * This enumerated attribute is intended to provide a hint to the browser about what the author thinks will lead to the best user experience. You may choose to include this attribute as a boolean attribute without a value, or you may specify the value preload="auto" to preload the beginning of the video. Not including the attribute or using preload="metadata" will just load the metadata needed to start video playback when requested.
+   *
+   * The <video> element does not force the browser to follow the value of this attribute; it is a mere hint. Even though the preload="none" option is a valid HTML5 attribute, Stream player will always load some metadata to initialize the player. The amount of data loaded in this case is negligable.
+   */
+  preload?: Preload;
+  /**
+   * Automatically manages the aspect ratio of the iframe for you. Defaults to true. If you want to manually handle the styles yourself, set this to false.
+   */
+  responsive?: boolean;
+  /**
+   * Either the video id or the signed url for the video you’ve uploaded to Cloudflare Stream should be included here.
+   */
+  src: string;
+  /**
+   * Ref for accessing the underlying stream element. Useful for providing imperative access to the player API:
+   * https://developers.cloudflare.com/stream/viewing-videos/using-the-player-api
+   */
+  streamRef?: MutableRefObject<StreamPlayerApi | undefined>;
+  /**
+   * Sets volume from 0.0 (silent) to 1.0 (maximum value)
+   */
+  volume?: number;
+  /**
+   * The width of the video’s display area, in CSS pixels.
+   */
+  width?: string;
+  /**
+   * Sent when playback is aborted; for example, if the media is playing and is restarted from the beginning, this event is sent.
+   */
+  onAbort?: () => void;
+  /**
+   * Sent when enough data is available that the media can be played, at least for a couple of frames.
+   */
+  onCanPlay?: () => void;
+  /**
+   * Sent when the entire media can be played without interruption, assuming the download rate remains at least at the current level. It will also be fired when playback is toggled between paused and playing. Note: Manually setting the currentTime will eventually fire a canplaythrough event in firefox. Other browsers might not fire this event.
+   */
+  onCanPlayThrough?: () => void;
+  /**
+   * The metadata has loaded or changed, indicating a change in duration of the media. This is sent, for example, when the media has loaded enough that the duration is known.
+   */
+  onDurationChange?: () => void;
+  /**
+   * Sent when playback completes.
+   */
+  onEnded?: () => void;
+  /**
+   * Sent when an error occurs. (e.g. the video has not finished encoding yet, or the video fails to load due to an incorrect signed URL)
+   */
+  onError?: () => void;
+  /**
+   * The first frame of the media has finished loading.
+   */
+  onLoadedData?: () => void;
+  /**
+   * The media’s metadata has finished loading; all attributes now contain as much useful information as they’re going to.
+   */
+  onLoadedMetaData?: () => void;
+  /**
+   * Sent when loading of the media begins.
+   */
+  onLoadStart?: () => void;
+  /**
+   * Sent when the playback state is changed to paused (paused property is true).
+   */
+  onPause?: () => void;
+  /**
+   * Sent when the playback state is no longer paused, as a result of the play method, or the autoplay attribute.
+   */
+  onPlay?: () => void;
+  /**
+   * Sent when the media has enough data to start playing, after the play event, but also when recovering from being stalled, when looping media restarts, and after seeked, if it was playing before seeking.
+   */
+  onPlaying?: () => void;
+  /**
+   * Sent periodically to inform interested parties of progress downloading the media. Information about the current amount of the media that has been downloaded is available in the media element’s buffered attribute.
+   */
+  onProgress?: () => void;
+  /**
+   * Sent when the playback speed changes.
+   */
+  onRateChange?: () => void;
+  /**
+   * Sent when the video's intrinsic dimensions (videoHeight & videoWidth) change.
+   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLVideoElement/videoHeight
+   */
+  onResize?: () => void;
+  /**
+   * Sent when a seek operation completes.
+   */
+  onSeeked?: () => void;
+  /**
+   * Sent when a seek operation begins.
+   */
+  onSeeking?: () => void;
+  /**
+   * Sent when the user agent is trying to fetch media data, but data is unexpectedly not forthcoming.
+   */
+  onStalled?: () => void;
+  /**
+   * Sent when loading of the media is suspended; this may happen either because the download has completed or because it has been paused for any other reason.
+   */
+  onSuspend?: () => void;
+  /**
+   * The time indicated by the element’s currentTime attribute has changed.
+   */
+  onTimeUpdate?: () => void;
+  /**
+   * Sent when the audio volume changes (both when the volume is set and when the muted attribute is changed).
+   */
+  onVolumeChange?: () => void;
+  /**
+   * Sent when the requested operation (such as playback) is delayed pending the completion of another operation (such as a seek).
+   */
+  onWaiting?: () => void;
+  /**
+   * Fires when ad-url attribute is present and the ad begins playback
+   */
+  onStreamAdStart?: () => void;
+  /**
+   * Fires when ad-url attribute is present and the ad finishes playback
+   */
+  onStreamAdEnd?: () => void;
+  /**
+   * Fires when ad-url attribute is present and the ad took too long to load.
+   */
+  onStreamAdTimeout?: () => void;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export interface StreamPlayerApi {
    */
   autoplay: boolean;
   /**
-   * Shows the default video controls such as buttons for play/pause, volume controls. You may choose to build buttons and controls that work with the player.
+   * Shows the default video controls such as buttons for play/pause, volume controls. You may choose to build buttons and controls that work with the player. If you hide controls, you may choose to build custom buttons and controls that work with the player.
    */
   controls: boolean;
   /**
@@ -106,7 +106,7 @@ export interface StreamProps {
    */
   className?: string;
   /**
-   * Shows the default video controls such as buttons for play/pause, volume controls. You may choose to build buttons and controls that work with the player.
+   * Shows the default video controls such as buttons for play/pause, volume controls. You may choose to build buttons and controls that work with the player. If you hide controls, you may choose to build custom buttons and controls that work with the player.
    */
   controls?: boolean;
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, CSSProperties } from "react";
+import { MutableRefObject } from "react";
 
 declare global {
   interface Window {

--- a/src/useIframeSrc.tsx
+++ b/src/useIframeSrc.tsx
@@ -1,0 +1,39 @@
+import { useMemo } from "react";
+import { Preload } from "./types";
+
+interface IframeSrcOptions {
+  muted?: boolean;
+  loop?: boolean;
+  autoplay?: boolean;
+  controls?: boolean;
+  poster?: string;
+  adUrl?: string;
+  preload?: Preload;
+}
+
+export function useIframeSrc(
+  src: string,
+  { muted, preload, loop, autoplay, controls, poster, adUrl }: IframeSrcOptions
+) {
+  const paramString = [
+    poster && `poster=${encodeURIComponent(poster)}`,
+    adUrl && `ad-url=${encodeURIComponent(adUrl)}`,
+    muted && "muted=true",
+    preload && `preload=${preload}`,
+    loop && "loop=true",
+    autoplay && "autoplay=true",
+    !controls && "controls=false",
+  ]
+    .filter(Boolean)
+    .join("&");
+
+  const iframeSrc = useMemo(
+    () => `https://iframe.videodelivery.net/${src}?${paramString}`,
+    // we intentionally do NOT include paramString here because we want
+    // to avoid changing the URL when these options change. Changes to
+    // these options will instead be handled separately via the SDK.
+    [src]
+  );
+
+  return iframeSrc;
+}

--- a/src/useStreamSDK.ts
+++ b/src/useStreamSDK.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from "react";
+
+const sdkScriptLocation = "https://embed.videodelivery.net/embed/sdk.latest.js";
+
+export function useStreamSDK() {
+  // Because we're storing the Stream function in state, we need to pass a
+  // function in that returns it because React will invoke functions that
+  // are passed into state
+  const [streamSdk, setStreamSdk] = useState(() => window.Stream);
+
+  useEffect(() => {
+    if (!streamSdk) {
+      const existingScript = document.querySelector<HTMLScriptElement>(
+        `script[src='https://embed.videodelivery.net/embed/sdk.latest.js']`
+      );
+      const script = existingScript ?? document.createElement("script");
+      script.addEventListener("load", () => {
+        // Same thing here, passing in a function that will return window.Stream
+        setStreamSdk(() => window.Stream);
+      });
+      if (!existingScript) {
+        script.src = sdkScriptLocation;
+        document.head.appendChild(script);
+      }
+    }
+  }, [streamSdk]);
+
+  return streamSdk;
+}

--- a/src/useStreamSDK.ts
+++ b/src/useStreamSDK.ts
@@ -11,7 +11,7 @@ export function useStreamSDK() {
   useEffect(() => {
     if (!streamSdk) {
       const existingScript = document.querySelector<HTMLScriptElement>(
-        `script[src='https://embed.videodelivery.net/embed/sdk.latest.js']`
+        `script[src='${sdkScriptLocation}']`
       );
       const script = existingScript ?? document.createElement("script");
       script.addEventListener("load", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,6 @@
     "strictPropertyInitialization": true,
     "noImplicitThis": true,
     "alwaysStrict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",


### PR DESCRIPTION
This PR updates the package to use the `<iframe />` embed API and SDK, which is [the preferred method of embedding the Stream player](https://developers.cloudflare.com/stream/viewing-videos/using-the-player-api).

The main changes are:
- We no longer use the `<stream />` element, which means any CSS that targets the `<stream />` element will no longer apply, and the `streamRef` prop is now of type `StreamPlayerApi`. The interface for controlling the video is the same as the `<stream />` element.
- We now have a `responsive` prop which will be on by default since most users will want the player to be constrained by its width and have its aspect ratio enforced. Users who don't want these styles can set `responsive={false}` and then style the elements themselves via CSS