### PR TITLE
Add responsive prop to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ export type StreamProps = {
    */
   preload?: "auto" | "metadata" | "none" | boolean;
   /**
+   * Automatically manages the aspect ratio of the iframe for you. Defaults to true. If you want to manually handle the styles yourself, set this to false.
+   */
+  responsive?: boolean;
+  /**
    * Sets volume from 0.0 (silent) to 1.0 (maximum value)
    */
   volume?: number;


### PR DESCRIPTION
This prop was documented in the prop types, but it looks like we forgot
to copy this over into the readme when it was added.