### PR TITLE
Fix exported types

### DIFF
--- a/src/Stream.tsx
+++ b/src/Stream.tsx
@@ -8,7 +8,7 @@ import React, {
   useMemo,
   MutableRefObject,
 } from "react";
-import { StreamPlayerApi, StreamProps, VideoDimensions } from "types";
+import { StreamPlayerApi, StreamProps, VideoDimensions } from "./types";
 import { useStreamSDK, safelyAccessStreamSDK } from "./useStreamSDK";
 import { useIframeSrc } from "./useIframeSrc";
 import { validSrcUrl } from "./validSrcUrl";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,7 @@
     "moduleResolution": "node",
     "baseUrl": "./",
     "paths": {
-      "@": ["./"],
-      "*": ["src/*", "node_modules/*"]
+      "*": ["node_modules/*"]
     },
     "jsx": "react",
     "esModuleInterop": true


### PR DESCRIPTION
This path should be relative. Without being relative, the exported types
do not work.