### PR TITLE
Allow cloudflarestream.com URLs too

### DIFF
--- a/src/validSrcUrl.ts
+++ b/src/validSrcUrl.ts
@@ -1,7 +1,7 @@
 export function validSrcUrl(str: string) {
   try {
     const url = new URL(str);
-    return url.hostname.endsWith("videodelivery.net");
+    return url.hostname.endsWith("videodelivery.net") || url.hostname.endsWith("cloudflarestream.com");
   } catch {
     return false;
   }


### PR DESCRIPTION
Hello,

Since last week, we have been having users with DNS resolution problems. We contacted Cloudflare support and they suggested using `cloudflarestream.com` instead. 