### PR TITLE
Add optional customerCode prop

### DIFF
--- a/src/Stream.tsx
+++ b/src/Stream.tsx
@@ -91,6 +91,7 @@ const Container: FC<{
 
 export const StreamEmbed: FC<StreamProps> = ({
   src,
+  customerCode,
   adUrl,
   controls = false,
   muted = false,
@@ -147,6 +148,7 @@ export const StreamEmbed: FC<StreamProps> = ({
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const computedSrc = useIframeSrc(src, {
+    customerCode,
     muted,
     preload,
     loop,

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,11 @@ export interface StreamProps {
    */
   currentTime?: number;
   /**
+   * Use unique subdomain for iframe source
+   * customer-<CODE>.cloudflarestream.com
+   */
+  customerCode?: string;
+  /**
    * Will initialize the player with the specified text track enabled. The value should be the BCP-47 language code that was used to [upload the text track](https://developers.cloudflare.com/stream/uploading-videos/adding-captions).
    * Note: This will _only_ work once during initialization. Beyond that point the user has full control over their text track settings.
    */

--- a/src/useIframeSrc.tsx
+++ b/src/useIframeSrc.tsx
@@ -13,6 +13,7 @@ interface IframeSrcOptions {
   adUrl?: string;
   defaultTextTrack?: string;
   preload?: Preload;
+  customerCode?: string;
 }
 
 export function useIframeSrc(
@@ -29,6 +30,7 @@ export function useIframeSrc(
     adUrl,
     startTime,
     defaultTextTrack,
+    customerCode
   }: IframeSrcOptions
 ) {
   const paramString = [
@@ -49,7 +51,7 @@ export function useIframeSrc(
     .join("&");
 
   const iframeSrc = useMemo(
-    () => `https://iframe.cloudflarestream.com/${src}?${paramString}`,
+    () => customerCode ? `https://customer-${customerCode}.cloudflarestream.com/${src}?${paramString}` : `https://iframe.cloudflarestream.com/${src}?${paramString}`,
     // we intentionally do NOT include paramString here because we want
     // to avoid changing the URL when these options change. Changes to
     // these options will instead be handled separately via the SDK.


### PR DESCRIPTION
From https://github.com/cloudflare/stream-react/issues/73

> _This will make it easy to pass the customer code as a prop to use the unique subdomain for user's Stream account._