### PR TITLE
pin yarn version

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.19.cjs


### PR DESCRIPTION
Looks like this project was using yarn 1.x, and I ran into issues trying to run `yarn` to install when using yarn 2.x.

This will pin the project to use yarn 1.x